### PR TITLE
external dns first draft

### DIFF
--- a/terraform/wifi-289708231103/dns/main.tf
+++ b/terraform/wifi-289708231103/dns/main.tf
@@ -18,3 +18,7 @@ terraform {
 resource "aws_route53_zone" "main" {
   name = var.main_zone_name
 }
+
+output "zone_id" {
+  value = aws_route53_zone.main.zone_id
+}


### PR DESCRIPTION
added the role into the cluster, i dont feel like moving this to a separate file, unless we want to move autoscaler as well, since this is implemented exactly like autoscaler