### PR TITLE
WIFI-1072: scaled up QA cluster to c5.xlarge

### DIFF
--- a/terraform/wifi-289708231103/cloudsdk_qa/terraform.tfvars
+++ b/terraform/wifi-289708231103/cloudsdk_qa/terraform.tfvars
@@ -11,11 +11,11 @@ org = "tip"
 node_group_settings = {
   max_capacity  = 4
   min_capacity  = 1
-  instance_type = "m5.large"
-  ami_name      = "amazon-eks-node-1.17-v20200814"
+  instance_type = "c5.xlarge"
+  ami_name      = "amazon-eks-node-1.18-v20201007"
 }
 
-cluster_version = "1.17"
+cluster_version = "1.18"
 
 eks_admin_roles = ["AWSReservedSSO_SystemAdministrator_622371b0ceece6f8"]
 


### PR DESCRIPTION
https://telecominfraproject.atlassian.net/browse/WIFI-1072

- scaled up QA cluster to c5.xlarge (WIFI-1072);
- finished upgrade to 1.18 (WIFI-1073);