### PR TITLE
add OK action to CloudWatch alarms

### DIFF
--- a/terraform/wifi-289708231103/tip-wifi-vpn/alerts.tf
+++ b/terraform/wifi-289708231103/tip-wifi-vpn/alerts.tf
@@ -13,6 +13,7 @@ resource "aws_cloudwatch_metric_alarm" "vpn_state" {
   threshold         = "0"
   alarm_description = "VPN Tunnel State"
   alarm_actions     = [aws_sns_topic.vpn_cloudwatch_alarms.arn]
+  ok_actions        = [aws_sns_topic.vpn_cloudwatch_alarms.arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "vpn_outgoing_data" {
@@ -31,6 +32,7 @@ resource "aws_cloudwatch_metric_alarm" "vpn_outgoing_data" {
   unit              = "Bytes"
   alarm_description = "VPN Outgoing Data"
   alarm_actions     = [aws_sns_topic.vpn_cloudwatch_alarms.arn]
+  ok_actions        = [aws_sns_topic.vpn_cloudwatch_alarms.arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "tgw_incoming" {
@@ -47,6 +49,7 @@ resource "aws_cloudwatch_metric_alarm" "tgw_incoming" {
   threshold         = "100000000000" # 100GB
   alarm_description = "Transit Gateway Incoming Data"
   alarm_actions     = [aws_sns_topic.vpn_cloudwatch_alarms.arn]
+  ok_actions        = [aws_sns_topic.vpn_cloudwatch_alarms.arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "tgw_outgoing_data" {
@@ -63,6 +66,7 @@ resource "aws_cloudwatch_metric_alarm" "tgw_outgoing_data" {
   threshold         = "100000000000" # 100GB
   alarm_description = "Transit Gateway Outgoing Data"
   alarm_actions     = [aws_sns_topic.vpn_cloudwatch_alarms.arn]
+  ok_actions        = [aws_sns_topic.vpn_cloudwatch_alarms.arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "tgw_packet_drops" {
@@ -72,6 +76,7 @@ resource "aws_cloudwatch_metric_alarm" "tgw_packet_drops" {
   threshold           = "0"
   alarm_description   = "Transit Gateway Packet Drops"
   alarm_actions       = [aws_sns_topic.vpn_cloudwatch_alarms.arn]
+  ok_actions          = [aws_sns_topic.vpn_cloudwatch_alarms.arn]
 
   metric_query {
     id          = "total_drops"


### PR DESCRIPTION
Will result in notifications being sent when the monitored metric goes back to it's normal behavior.