### PR TITLE
update module version + fix cert validation records

### DIFF
--- a/terraform/wifi-289708231103/cloudsdk_cicd/alb_ingress_controller.tf
+++ b/terraform/wifi-289708231103/cloudsdk_cicd/alb_ingress_controller.tf
@@ -1,5 +1,5 @@
 module "alb_ingress_iam_role" {
-  source       = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-assumable-role-with-oidc?ref=v2.12.0"
+  source       = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-assumable-role-with-oidc?ref=v2.25.0"
   role_name    = "${module.eks.cluster_id}-alb-ingress"
   provider_url = local.oidc_provider_url
   role_policy_arns = [

--- a/terraform/wifi-289708231103/cloudsdk_cicd/cloudsdk_lb_shared_resources.tf
+++ b/terraform/wifi-289708231103/cloudsdk_cicd/cloudsdk_lb_shared_resources.tf
@@ -90,11 +90,20 @@ resource "aws_acm_certificate" "cloudsdk" {
 }
 
 resource "aws_route53_record" "cloudsdk_ssl_validation" {
-  zone_id = data.terraform_remote_state.route_53.outputs.zone_id
-  name    = aws_acm_certificate.cloudsdk.domain_validation_options.0.resource_record_name
-  type    = aws_acm_certificate.cloudsdk.domain_validation_options.0.resource_record_type
-  ttl     = 600
+  for_each = {
+    for dvo in aws_acm_certificate.cloudsdk.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  zone_id         = data.terraform_remote_state.route_53.outputs.zone_id
+  name            = each.value.type
+  type            = each.value.type
+  ttl             = 600
+  allow_overwrite = true
   records = [
-    aws_acm_certificate.cloudsdk.domain_validation_options.0.resource_record_value
+    each.value.record
   ]
 }

--- a/terraform/wifi-289708231103/cloudsdk_cicd/eks.tf
+++ b/terraform/wifi-289708231103/cloudsdk_cicd/eks.tf
@@ -119,7 +119,7 @@ data "terraform_remote_state" "route_53" {
 }
 
 module "external_dns_cluster_role" {
-  source           = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-assumable-role-with-oidc?ref=v2.12.0"
+  source           = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-assumable-role-with-oidc?ref=v2.25.0"
   role_name        = "${module.eks.cluster_id}-external-dns"
   provider_url     = local.oidc_provider_url
   role_policy_arns = [aws_iam_policy.external_dns.arn]
@@ -177,7 +177,7 @@ data "aws_iam_policy_document" "external_dns" {
 }
 
 module "cluster_autoscaler_cluster_role" {
-  source           = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-assumable-role-with-oidc?ref=v2.12.0"
+  source           = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-assumable-role-with-oidc?ref=v2.25.0"
   role_name        = "${module.eks.cluster_id}-cluster-autoscaler"
   provider_url     = local.oidc_provider_url
   role_policy_arns = [aws_iam_policy.cluster_autoscaler.arn]

--- a/terraform/wifi-289708231103/cloudsdk_cicd/vpc.tf
+++ b/terraform/wifi-289708231103/cloudsdk_cicd/vpc.tf
@@ -1,5 +1,5 @@
 module "vpc_main" {
-  source               = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v2.33.0"
+  source               = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v2.64.0"
   name                 = "${var.org}-${var.project}-${var.env}"
   cidr                 = var.vpc_cidr
   azs                  = [for az in var.az : format("%s%s", var.aws_region, az)]

--- a/terraform/wifi-289708231103/cloudsdk_qa/alb_ingress_controller.tf
+++ b/terraform/wifi-289708231103/cloudsdk_qa/alb_ingress_controller.tf
@@ -1,5 +1,5 @@
 module "alb_ingress_iam_role" {
-  source       = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-assumable-role-with-oidc?ref=v2.12.0"
+  source       = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-assumable-role-with-oidc?ref=v2.25.0"
   role_name    = "${module.eks.cluster_id}-alb-ingress"
   provider_url = local.oidc_provider_url
   role_policy_arns = [

--- a/terraform/wifi-289708231103/cloudsdk_qa/eks.tf
+++ b/terraform/wifi-289708231103/cloudsdk_qa/eks.tf
@@ -111,7 +111,7 @@ data "terraform_remote_state" "route_53" {
 }
 
 module "external_dns_cluster_role" {
-  source           = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-assumable-role-with-oidc?ref=v2.12.0"
+  source           = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-assumable-role-with-oidc?ref=v2.25.0"
   role_name        = "${module.eks.cluster_id}-external-dns"
   provider_url     = local.oidc_provider_url
   role_policy_arns = [aws_iam_policy.external_dns.arn]
@@ -169,7 +169,7 @@ data "aws_iam_policy_document" "external_dns" {
 }
 
 module "cluster_autoscaler_cluster_role" {
-  source           = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-assumable-role-with-oidc?ref=v2.12.0"
+  source           = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-assumable-role-with-oidc?ref=v2.25.0"
   role_name        = "${module.eks.cluster_id}-cluster-autoscaler"
   provider_url     = local.oidc_provider_url
   role_policy_arns = [aws_iam_policy.cluster_autoscaler.arn]

--- a/terraform/wifi-289708231103/cloudsdk_qa/vpc.tf
+++ b/terraform/wifi-289708231103/cloudsdk_qa/vpc.tf
@@ -1,5 +1,5 @@
 module "vpc_main" {
-  source               = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v2.33.0"
+  source               = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v2.64.0"
   name                 = "${var.org}-${var.project}-${var.env}"
   cidr                 = var.vpc_cidr
   azs                  = [for az in var.az : format("%s%s", var.aws_region, az)]


### PR DESCRIPTION
The code for the Route 53 records is based on [this example code](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate#referencing-domain_validation_options-with-for_each-based-resources).