### PR TITLE
fix Grafana dashboard for JVM metrics

### DIFF
--- a/helmfile/cloud-sdk/grafana-dashboards/jvm-metrics-per-pod.json
+++ b/helmfile/cloud-sdk/grafana-dashboards/jvm-metrics-per-pod.json
@@ -1608,7 +1608,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "$datasource",
         "definition": "label_values(jvm_info, namespace)",
         "description": null,
         "error": null,
@@ -1618,10 +1618,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": {
-          "query": "label_values(jvm_info, namespace)",
-          "refId": "StandardVariableQuery"
-        },
+        "query": "label_values(jvm_info, namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1635,7 +1632,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "$datasource",
         "definition": "label_values(jvm_info{namespace=\"$namespace\"},pod)",
         "description": null,
         "error": null,
@@ -1645,10 +1642,7 @@
         "multi": false,
         "name": "pod",
         "options": [],
-        "query": {
-          "query": "label_values(jvm_info{namespace=\"$namespace\"},pod)",
-          "refId": "StandardVariableQuery"
-        },
+        "query": "label_values(jvm_info{namespace=\"$namespace\"},pod)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1672,10 +1666,7 @@
         "multi": true,
         "name": "mempool",
         "options": [],
-        "query": {
-          "query": "label_values(jvm_memory_pool_bytes_max{namespace=\"$namespace\", pod=\"$pod\"}, pool)",
-          "refId": "StandardVariableQuery"
-        },
+        "query": "label_values(jvm_memory_pool_bytes_max{namespace=\"$namespace\", pod=\"$pod\"}, pool)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1699,10 +1690,7 @@
         "multi": true,
         "name": "memarea",
         "options": [],
-        "query": {
-          "query": "label_values(jvm_memory_bytes_used{namespace=\"$namespace\", pod=\"$pod\"}, area)",
-          "refId": "Prometheus-memarea-Variable-Query"
-        },
+        "query": "label_values(jvm_memory_bytes_used{namespace=\"$namespace\", pod=\"$pod\"}, area)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/helmfile/cloud-sdk/helmfile.yaml
+++ b/helmfile/cloud-sdk/helmfile.yaml
@@ -244,8 +244,9 @@ releases:
             # revision: 1
             datasource: Prometheus
           jvm-metrics-per-pod:
-            file: grafana-dashboards/jvm-metrics-per-pod.json
             datasource: Prometheus
+            json: |
+            {{- readFile "grafana-dashboards/jvm-metrics-per-pod.json" | nindent 14 }}
 
       datasources:
        datasources.yaml:


### PR DESCRIPTION
Had to make some fixes to the JVM metrics dashboard.

Resulting dashboard is here: https://grafana.lab.wlan.tip.build/d/jvm-metrics-per-pod/jvm-metrics-per-pod?orgId=1&refresh=5m&var-datasource=Prometheus&var-namespace=tip-max-testbed&var-pod=tip-max-testbed-wlan-port-forwarding-gateway-service-54bfdqhzpg&var-mempool=All&var-memarea=All