### PR TITLE
ignore pods with local storage when scaling down

### DIFF
--- a/helmfile/cloud-sdk/envs/common/cluster-autoscaler.yaml.gotmpl
+++ b/helmfile/cloud-sdk/envs/common/cluster-autoscaler.yaml.gotmpl
@@ -14,6 +14,7 @@ rbac:
 extraArgs:
   balance-similar-node-groups: true
   skip-nodes-with-system-pods: false
+  skip-nodes-with-local-storage: false
   expander: priority
 
 expanderPriorities: |-


### PR DESCRIPTION
We (should) only use local storage for temporary storage so pods using it can be ignored by the cluster autoscaler. 