### PR TITLE
increase Prometheus data retention to 31 days

### DIFF
--- a/helmfile/cloud-sdk/helmfile.yaml
+++ b/helmfile/cloud-sdk/helmfile.yaml
@@ -170,6 +170,7 @@ releases:
   - prometheus:
       enabled: true
       prometheusSpec:
+        retention: 31d
         resources:
           requests:
             memory: 1400Mi


### PR DESCRIPTION
Have encountered the issue of not having enough historical data that would have helped so this should help in the future.