### PR TITLE
[WIFI-2892] Investigate why Atlassian backup has failed during the weekend

### DIFF
--- a/terraform/backups-929991548720/images/build_image_atlassian_cloud_backup/backup_atlassian_cloud.py
+++ b/terraform/backups-929991548720/images/build_image_atlassian_cloud_backup/backup_atlassian_cloud.py
@@ -70,7 +70,7 @@ class AtlassianBackup:
             backup_progress_res = self.session.get(backup_progress_url).json()
             print(f"Debug: {backup_progress_res}")
 
-            if backup_progress_res["alternativePercentage"] == "100%":
+            if backup_progress_res["alternativePercentage"] == "100%" and "fileName" in backup_progress_res:
                 return backup_progress_res["fileName"]
 
             else:


### PR DESCRIPTION
Add condition to prevent failure if backup is finished and the `fileName` key is missing. Process should also wait for the key to be present in the response and go into a timeout if it isn't after the defined period.