### PR TITLE
Increase Atlassian backup timeout

### DIFF
--- a/terraform/backups-929991548720/images/build_image_atlassian_cloud_backup/backup_atlassian_cloud.py
+++ b/terraform/backups-929991548720/images/build_image_atlassian_cloud_backup/backup_atlassian_cloud.py
@@ -66,7 +66,7 @@ class AtlassianBackup:
             self.base_url, "/wiki/rest/obm/1.0/getprogress"
         )
 
-        for _ in range(360):
+        for _ in range(720):
             backup_progress_res = self.session.get(backup_progress_url).json()
             print(f"Debug: {backup_progress_res}")
 
@@ -87,7 +87,7 @@ class AtlassianBackup:
             self.base_url, f"/rest/backup/1/export/getProgress?taskId={task_id}"
         )
 
-        for _ in range(360):
+        for _ in range(720):
             backup_progress_res = self.session.get(backup_progress_url).json()
             if backup_progress_res["status"] == "Success":
                 return backup_progress_res["result"]


### PR DESCRIPTION
Especially the Confluence backup can take a long time until it is available for download, which is why we need to increase the timeout to two hours instead of one.