### PR TITLE
upgrade cluster autoscaler

### DIFF
--- a/helmfile/cloud-sdk/envs/common/cluster-autoscaler.yaml.gotmpl
+++ b/helmfile/cloud-sdk/envs/common/cluster-autoscaler.yaml.gotmpl
@@ -1,7 +1,7 @@
 replicaCount: 1
 image:
-  repository: us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler
-  tag: v1.17.3
+  repository: k8s.gcr.io/autoscaling/cluster-autoscaler
+  tag: v1.20.2
 autoDiscovery:
   clusterName: {{ .Environment.Values.eks.clusterName }}
 awsRegion: {{ .Environment.Values.eks.region }}
@@ -9,8 +9,9 @@ priorityClassName: system-cluster-critical
 rbac:
   create: true
   pspEnabled: true
-  serviceAccountAnnotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Environment.Values.eks.accountID }}:role/{{ .Environment.Values.eks.clusterName }}-cluster-autoscaler
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Environment.Values.eks.accountID }}:role/{{ .Environment.Values.eks.clusterName }}-cluster-autoscaler
 extraArgs:
   balance-similar-node-groups: true
   skip-nodes-with-system-pods: false

--- a/helmfile/cloud-sdk/helmfile.lock
+++ b/helmfile/cloud-sdk/helmfile.lock
@@ -13,8 +13,8 @@ dependencies:
   repository: https://charts.jetstack.io
   version: v1.4.0
 - name: cluster-autoscaler
-  repository: https://charts.helm.sh/stable
-  version: 7.3.2
+  repository: https://kubernetes.github.io/autoscaler/
+  version: 9.11.0
 - name: elasticsearch
   repository: https://charts.helm.sh/stable
   version: 1.32.5

--- a/helmfile/cloud-sdk/helmfile.yaml
+++ b/helmfile/cloud-sdk/helmfile.yaml
@@ -11,6 +11,8 @@ repositories:
   url: https://helm.elastic.co
 - name: kubernetes-dashboard
   url: https://kubernetes.github.io/dashboard/
+- name: autoscaler
+  url: https://kubernetes.github.io/autoscaler/
 - name: bitnami
   url: https://charts.bitnami.com/bitnami
 - name: influxdata
@@ -115,8 +117,8 @@ releases:
   condition: autoscaler.enabled
   <<: *default 
   <<: *cluster-autoscaler
-  chart: stable/cluster-autoscaler
-  version: 7.3.2
+  chart: autoscaler/cluster-autoscaler
+  version: 9.11.0
   labels:
     role: setup
     group: system


### PR DESCRIPTION
- migrating away from stable Helm repo
- upgrade cluster autoscaler to v1.20.2