### PR TITLE
update kube-prometheus-stack

### DIFF
--- a/helmfile/cloud-sdk/helmfile.lock
+++ b/helmfile/cloud-sdk/helmfile.lock
@@ -38,7 +38,7 @@ dependencies:
   version: 3.2.8
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 26.1.0
+  version: 30.0.0
 - name: kubernetes-dashboard
   repository: https://kubernetes.github.io/dashboard/
   version: 5.0.3

--- a/helmfile/cloud-sdk/helmfile.yaml
+++ b/helmfile/cloud-sdk/helmfile.yaml
@@ -177,16 +177,13 @@ releases:
   condition: prometheus.enabled
   namespace: {{ .Environment.Values.monitoring.namespace }}
   chart: prometheus-community/kube-prometheus-stack
-  version: 26.1.0
+  version: 30.0.0
   labels:
     role: setup
     group: monitoring
     app: prometheus-operator
   values:
   - nameOverride: prometheus-operator
-  - prometheusOperator:
-      manageCrds: true
-      createCustomResource: false
   - prometheus:
       enabled: true
       prometheusSpec:


### PR DESCRIPTION
- version 30.0.0 enables automatically gathering pod metrics again
- remove some outdated chart params