### PR TITLE
allow S3 uploader object tagging

### DIFF
--- a/terraform/wifi-289708231103/ucentral-ap-s3/main.tf
+++ b/terraform/wifi-289708231103/ucentral-ap-s3/main.tf
@@ -113,7 +113,8 @@ resource "aws_iam_user_policy" "uploader" {
           "s3:ListBucketMultipartUploads",
           "s3:GetObject",
           "s3:PutObject",
-          "s3:PutObjectAcl"
+          "s3:PutObjectAcl",
+          "s3:PutObjectTagging"
         ],
         "Effect" : "Allow",
         "Resource" : [


### PR DESCRIPTION
Required for changes in https://github.com/Telecominfraproject/wlan-ap/pull/426